### PR TITLE
Issue/37 App crashes when no connection to nats

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
Change indent_size in editorconfig to 4 and add try/catch block to prevent app crashes when trying to connect JetStream consumer to a connection that does not exist.

Error log example (one-line log for ELK support):
```
0|server  | [Nest] 309597  - 07/27/2023, 6:37:03 PM   ERROR [NatsListenerService] No connection established to NATS: {"moduleName":"moduleName_1","className":"className_1","methodName":"methodName_1","consumerName":"consumerName_1","streamName":"streamName_1"}
```